### PR TITLE
Update 6312-MUI6 showcase

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@mui/docs": "^6.1.4",
         "@mui/envinfo": "^2.0.28",
         "@mui/icons-material": "^6.1.4",
-        "@mui/lab": "^6.0.0-beta.12",
+        "@mui/lab": "^6.0.0-beta.14",
         "@mui/material": "^6.1.4",
         "@mui/private-theming": "^6.1.4",
         "@mui/styled-engine": "^6.1.4",

--- a/src/__tests__/blui-tests/__snapshots__/Components.test.tsx.snap
+++ b/src/__tests__/blui-tests/__snapshots__/Components.test.tsx.snap
@@ -12,10 +12,8 @@ exports[`Component: ChannelValueExample ChannelValueExample renders examples cor
       Basic Usage
     </p>
     <span
-      className="BluiChannelValue-root cssltr-kek565"
-      color="inherit"
+      className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
       data-testid="blui-channel-value-root"
-      fontSize="inherit"
     >
       <h6
         className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -36,10 +34,8 @@ exports[`Component: ChannelValueExample ChannelValueExample renders examples cor
       w/ Units
     </p>
     <span
-      className="BluiChannelValue-root cssltr-kek565"
-      color="inherit"
+      className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
       data-testid="blui-channel-value-root"
-      fontSize="inherit"
     >
       <h6
         className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -67,10 +63,8 @@ exports[`Component: ChannelValueExample ChannelValueExample renders examples cor
       w/ Icon
     </p>
     <span
-      className="BluiChannelValue-root cssltr-kek565"
-      color="inherit"
+      className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
       data-testid="blui-channel-value-root"
-      fontSize="inherit"
     >
       <span
         className="BluiChannelValue-icon cssltr-1oqvg4e"
@@ -121,10 +115,8 @@ exports[`Component: ChannelValueExample ChannelValueExample renders examples cor
       w/ Custom Font Size
     </p>
     <span
-      className="BluiChannelValue-root cssltr-c8a5as"
-      color="inherit"
+      className="BluiChannelValue-root MuiBox-root cssltr-th3vuf"
       data-testid="blui-channel-value-root"
-      fontSize={24}
     >
       <span
         className="BluiChannelValue-icon cssltr-1oqvg4e"
@@ -180,11 +172,11 @@ exports[`Component: EmptyStateExample EmptyStateExample renders examples correct
       Basic Usage
     </p>
     <div
-      className="BluiEmptyState-root MuiBox-root cssltr-lyk9sl"
+      className="BluiEmptyState-root MuiBox-root cssltr-1n1qj8a"
       data-testid="blui-empty-state-root"
     >
       <div
-        className="BluiEmptyState-icon MuiBox-root cssltr-xipz7o"
+        className="BluiEmptyState-icon MuiBox-root cssltr-1qeq0w3"
       >
         <svg
           aria-hidden={true}
@@ -199,7 +191,7 @@ exports[`Component: EmptyStateExample EmptyStateExample renders examples correct
         </svg>
       </div>
       <h6
-        className="MuiTypography-root MuiTypography-h6 BluiEmptyState-title cssltr-5d0866-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h6 cssltr-5d0866-MuiTypography-root"
         style={{}}
       >
         Location Unknown
@@ -216,11 +208,11 @@ exports[`Component: EmptyStateExample EmptyStateExample renders examples correct
       w/ Description
     </p>
     <div
-      className="BluiEmptyState-root MuiBox-root cssltr-lyk9sl"
+      className="BluiEmptyState-root MuiBox-root cssltr-1n1qj8a"
       data-testid="blui-empty-state-root"
     >
       <div
-        className="BluiEmptyState-icon MuiBox-root cssltr-xipz7o"
+        className="BluiEmptyState-icon MuiBox-root cssltr-1qeq0w3"
       >
         <svg
           aria-hidden={true}
@@ -235,13 +227,13 @@ exports[`Component: EmptyStateExample EmptyStateExample renders examples correct
         </svg>
       </div>
       <h6
-        className="MuiTypography-root MuiTypography-h6 BluiEmptyState-title cssltr-5d0866-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h6 cssltr-5d0866-MuiTypography-root"
         style={{}}
       >
         Location Services Disabled
       </h6>
       <h6
-        className="MuiTypography-root MuiTypography-subtitle2 BluiEmptyState-description cssltr-1pp0zv-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-subtitle2 BluiEmptyState-description cssltr-1seh92d-MuiTypography-root"
         style={{}}
       >
         Enable Location Services via Settings to receive GPS information
@@ -255,11 +247,11 @@ exports[`Component: EmptyStateExample EmptyStateExample renders examples correct
     w/ Actions
   </p>,
   <div
-    className="BluiEmptyState-root MuiBox-root cssltr-lyk9sl"
+    className="BluiEmptyState-root MuiBox-root cssltr-1n1qj8a"
     data-testid="blui-empty-state-root"
   >
     <div
-      className="BluiEmptyState-icon MuiBox-root cssltr-xipz7o"
+      className="BluiEmptyState-icon MuiBox-root cssltr-1qeq0w3"
     >
       <svg
         aria-hidden={true}
@@ -274,13 +266,13 @@ exports[`Component: EmptyStateExample EmptyStateExample renders examples correct
       </svg>
     </div>
     <h6
-      className="MuiTypography-root MuiTypography-h6 BluiEmptyState-title cssltr-5d0866-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-h6 cssltr-5d0866-MuiTypography-root"
       style={{}}
     >
       No Devices
     </h6>
     <h6
-      className="MuiTypography-root MuiTypography-subtitle2 BluiEmptyState-description cssltr-1pp0zv-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-subtitle2 BluiEmptyState-description cssltr-1seh92d-MuiTypography-root"
       style={{}}
     >
       Check your network connection or add a new device
@@ -343,12 +335,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         Basic Usage
       </p>
       <div
-        className="BluiHero-root MuiBox-root cssltr-n0deun"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-xrulrs"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-1okws1c"
+          className="BluiHero-icon MuiBox-root cssltr-14pgf5l"
         >
           <svg
             aria-hidden={true}
@@ -366,7 +357,7 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         />
         <p
           className="MuiTypography-root MuiTypography-body1 BluiHero-label cssltr-1pn5hg5-MuiTypography-root"
@@ -386,12 +377,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         w/ Value and Units
       </p>
       <div
-        className="BluiHero-root MuiBox-root cssltr-n0deun"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-xrulrs"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-1okws1c"
+          className="BluiHero-icon MuiBox-root cssltr-14pgf5l"
         >
           <svg
             aria-hidden={true}
@@ -409,13 +399,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-kek565"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
             data-testid="blui-channel-value-root"
-            fontSize="inherit"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -455,12 +443,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         w/ Channel Value Children
       </p>
       <div
-        className="BluiHero-root MuiBox-root cssltr-n0deun"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-xrulrs"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-1okws1c"
+          className="BluiHero-icon MuiBox-root cssltr-14pgf5l"
         >
           <svg
             aria-hidden={true}
@@ -478,13 +465,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-1dtyrv9"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1ej03bs"
             data-testid="blui-channel-value-root"
-            fontSize="large"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -502,10 +487,8 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
             </h6>
           </span>
           <span
-            className="BluiChannelValue-root cssltr-1dtyrv9"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1ej03bs"
             data-testid="blui-channel-value-root"
-            fontSize="large"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -541,12 +524,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         w/ Icon Colors
       </p>
       <div
-        className="BluiHero-root MuiBox-root cssltr-n0deun"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-xrulrs"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-13sdyqh"
+          className="BluiHero-icon MuiBox-root cssltr-1lsp8cs"
         >
           <svg
             aria-hidden={true}
@@ -566,13 +548,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-kek565"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
             data-testid="blui-channel-value-root"
-            fontSize="inherit"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -610,16 +590,14 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
     </p>
     <div
       className="BluiHeroBanner-root MuiBox-root cssltr-1ehwgtw"
-      classes={{}}
       data-testid="blui-hero-banner-root"
     >
       <div
-        className="BluiHero-root MuiBox-root cssltr-2a12sz"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-bocl9p"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-1okws1c"
+          className="BluiHero-icon MuiBox-root cssltr-14pgf5l"
         >
           <svg
             aria-hidden={true}
@@ -637,13 +615,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-kek565"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
             data-testid="blui-channel-value-root"
-            fontSize="inherit"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -669,12 +645,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         </p>
       </div>
       <div
-        className="BluiHero-root MuiBox-root cssltr-2a12sz"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-bocl9p"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-1okws1c"
+          className="BluiHero-icon MuiBox-root cssltr-14pgf5l"
         >
           <svg
             aria-hidden={true}
@@ -692,13 +667,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-kek565"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
             data-testid="blui-channel-value-root"
-            fontSize="inherit"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -724,12 +697,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         </p>
       </div>
       <div
-        className="BluiHero-root MuiBox-root cssltr-2a12sz"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-bocl9p"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-1okws1c"
+          className="BluiHero-icon MuiBox-root cssltr-14pgf5l"
         >
           <svg
             aria-hidden={true}
@@ -747,13 +719,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-1dtyrv9"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1ej03bs"
             data-testid="blui-channel-value-root"
-            fontSize="large"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -771,10 +741,8 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
             </h6>
           </span>
           <span
-            className="BluiChannelValue-root cssltr-1dtyrv9"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1ej03bs"
             data-testid="blui-channel-value-root"
-            fontSize="large"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -800,12 +768,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
         </p>
       </div>
       <div
-        className="BluiHero-root MuiBox-root cssltr-2a12sz"
-        classes={{}}
+        className="BluiHero-root MuiBox-root cssltr-bocl9p"
         data-testid="blui-hero-root"
       >
         <div
-          className="BluiHero-icon MuiBox-root cssltr-13sdyqh"
+          className="BluiHero-icon MuiBox-root cssltr-1lsp8cs"
         >
           <svg
             aria-hidden={true}
@@ -825,13 +792,11 @@ exports[`Component: HeroExample HeroExample renders examples correctly 1`] = `
           </svg>
         </div>
         <span
-          className="BluiHero-values cssltr-v1bge9"
+          className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
         >
           <span
-            className="BluiChannelValue-root cssltr-kek565"
-            color="inherit"
+            className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
             data-testid="blui-channel-value-root"
-            fontSize="inherit"
           >
             <h6
               className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -879,7 +844,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1s0dv2i-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1lfrp4s-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -921,7 +886,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1s0dv2i-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1lfrp4s-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -950,7 +915,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with a Subtitle
@@ -974,7 +939,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-qwpipe-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-1igajn5-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1003,7 +968,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with an icon
@@ -1027,7 +992,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-w8i9qu-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-y3kntj-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1060,7 +1025,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           Item 1
@@ -1102,7 +1067,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1s0dv2i-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1lfrp4s-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1131,7 +1096,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with a partial divider
@@ -1159,7 +1124,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1s0dv2i-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1lfrp4s-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1188,7 +1153,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with a full divider
@@ -1197,7 +1162,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
     </div>
   </li>,
   <li
-    className="MuiListItem-root MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-gssocr-MuiListItem-root"
+    className="MuiListItem-root MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-uacsow-MuiListItem-root"
     onClick={[Function]}
   >
     <div
@@ -1230,7 +1195,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         }
       >
         <div
-          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1s0dv2i-MuiAvatar-root"
+          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-1lfrp4s-MuiAvatar-root"
         >
           <svg
             aria-hidden={true}
@@ -1259,7 +1224,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
           style={{}}
         >
           <div
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
             style={{}}
           >
             that is clickable
@@ -1284,7 +1249,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-30136s-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-avatar cssltr-uzru2t-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1316,7 +1281,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with an avatar
@@ -1340,7 +1305,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-qwpipe-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-1igajn5-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1373,7 +1338,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1cimvb7-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1lym8w5-MuiTypography-root"
           style={{}}
         >
           with a background color
@@ -1397,7 +1362,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-w8i9qu-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-y3kntj-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1443,7 +1408,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with a left component
@@ -1467,7 +1432,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       }
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-w8i9qu-MuiAvatar-root"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-y3kntj-MuiAvatar-root"
       >
         <svg
           aria-hidden={true}
@@ -1500,7 +1465,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         style={{}}
       >
         <div
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
           style={{}}
         >
           with a right component
@@ -1511,10 +1476,8 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
       className="BluiInfoListItem-rightComponent MuiBox-root cssltr-7i4b71"
     >
       <span
-        className="BluiChannelValue-root cssltr-kek565"
-        color="inherit"
+        className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
         data-testid="blui-channel-value-root"
-        fontSize="inherit"
       >
         <h6
           className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -1571,7 +1534,7 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
         }
       >
         <div
-          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-qwpipe-MuiAvatar-root"
+          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-1igajn5-MuiAvatar-root"
         >
           <svg
             aria-hidden={true}
@@ -1604,13 +1567,13 @@ exports[`Component: InfoListItemExample InfoListItemExample renders examples cor
           style={{}}
         >
           <div
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1cimvb7-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1lym8w5-MuiTypography-root"
             style={{}}
           >
             with all properties
           </div>
           <div
-            className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap BluiInfoListItem-info cssltr-1wq5f0m-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap BluiInfoListItem-info cssltr-v85ucy-MuiTypography-root"
             style={{}}
           >
             more info...
@@ -1637,7 +1600,7 @@ exports[`Component: ListItemTagExample ListItemTagExample renders examples corre
         Basic Usage
       </p>
       <span
-        className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-kimbzh-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-txwxd6-MuiTypography-root"
         data-testid="blui-list-item-tag"
         style={{}}
       >
@@ -1654,7 +1617,7 @@ exports[`Component: ListItemTagExample ListItemTagExample renders examples corre
         w/ Custom Colors
       </p>
       <span
-        className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-1lxi61j-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-16rhlxd-MuiTypography-root"
         data-testid="blui-list-item-tag"
         style={{}}
       >
@@ -1687,7 +1650,7 @@ exports[`Component: ListItemTagExample ListItemTagExample renders examples corre
         }
       >
         <div
-          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-w8i9qu-MuiAvatar-root"
+          className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-y3kntj-MuiAvatar-root"
         >
           <svg
             aria-hidden={true}
@@ -1716,7 +1679,7 @@ exports[`Component: ListItemTagExample ListItemTagExample renders examples corre
           style={{}}
         >
           <div
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-jvutuj-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-noWrap BluiInfoListItem-subtitle cssltr-1inmcri-MuiTypography-root"
             style={{}}
           >
             with List Item Tags
@@ -1730,14 +1693,14 @@ exports[`Component: ListItemTagExample ListItemTagExample renders examples corre
           className="MuiBox-root cssltr-k008qs"
         >
           <span
-            className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-nvgyxm-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-wufuvy-MuiTypography-root"
             data-testid="blui-list-item-tag"
             style={{}}
           >
             Build Passing
           </span>
           <span
-            className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-1flv5ll-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-overline MuiTypography-noWrap BluiListItemTag-root BluiListItemTag-noVariant cssltr-16e8zyu-MuiTypography-root"
             data-testid="blui-list-item-tag"
             style={{}}
           >
@@ -1788,10 +1751,8 @@ exports[`Component: ThreeLinerExample ThreeLinerExample renders examples correct
       className="BluiThreeLiner-info MuiBox-root cssltr-9q8ecb"
     >
       <span
-        className="BluiChannelValue-root cssltr-kek565"
-        color="inherit"
+        className="BluiChannelValue-root MuiBox-root cssltr-1flyiuq"
         data-testid="blui-channel-value-root"
-        fontSize="inherit"
       >
         <span
           className="BluiChannelValue-icon cssltr-1oqvg4e"
@@ -1854,7 +1815,7 @@ exports[`Component: UserMenuExample UserMenuExample renders examples correctly 1
         className="BluiUserMenu-root MuiBox-root cssltr-1c73i31"
       >
         <div
-          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-rtzpse-MuiAvatar-root"
+          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-6qsmld-MuiAvatar-root"
           onClick={[Function]}
         >
           UI
@@ -1874,7 +1835,7 @@ exports[`Component: UserMenuExample UserMenuExample renders examples correctly 1
         className="BluiUserMenu-root MuiBox-root cssltr-1c73i31"
       >
         <div
-          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-1io021o-MuiAvatar-root"
+          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-k0u9oz-MuiAvatar-root"
           onClick={[Function]}
         >
           UI
@@ -1898,7 +1859,7 @@ exports[`Component: UserMenuExample UserMenuExample renders examples correctly 1
         className="BluiUserMenu-root MuiBox-root cssltr-1c73i31"
       >
         <div
-          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-rtzpse-MuiAvatar-root"
+          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-6qsmld-MuiAvatar-root"
           onClick={[Function]}
         >
           <svg
@@ -1948,7 +1909,7 @@ exports[`Component: UserMenuExample UserMenuExample renders examples correctly 1
         className="BluiUserMenu-root MuiBox-root cssltr-1c73i31"
       >
         <div
-          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-rtzpse-MuiAvatar-root"
+          className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-6qsmld-MuiAvatar-root"
           onClick={[Function]}
         >
           UI
@@ -1979,14 +1940,13 @@ exports[`Component: UserMenuExample UserMenuExample renders examples correctly 1
         </h6>
         <div
           className="BluiSpacer-root MuiBox-root cssltr-jxy7be"
-          classes={{}}
           data-testid="blui-spacer-root"
         />
         <div
           className="BluiUserMenu-root MuiBox-root cssltr-1c73i31"
         >
           <div
-            className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-rtzpse-MuiAvatar-root"
+            className="MuiAvatar-root BluiUserMenu-avatarRoot MuiAvatar-circular MuiAvatar-colorDefault cssltr-6qsmld-MuiAvatar-root"
             onClick={[Function]}
           >
             <svg

--- a/src/__tests__/blui-tests/__snapshots__/Surfaces.test.tsx.snap
+++ b/src/__tests__/blui-tests/__snapshots__/Surfaces.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Component: BLUIAppBarExample BLUIAppBarExample renders examples correct
     className="MuiBox-root cssltr-fvxjzt"
   >
     <header
-      className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionSticky BluiAppBar-root Mui-expanded expanded cssltr-nx5hj5-MuiPaper-root-MuiAppBar-root"
+      className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionSticky BluiAppBar-root expanded cssltr-nx5hj5-MuiPaper-root-MuiAppBar-root"
       data-testid="blui-appbar-root"
       style={
         {
@@ -22,14 +22,9 @@ exports[`Component: BLUIAppBarExample BLUIAppBarExample renders examples correct
       >
         <div
           className="BluiThreeLiner-root liner MuiBox-root cssltr-uqb9nc"
-          classes={
-            {
-              "title": "title",
-            }
-          }
         >
           <div
-            className="BluiThreeLiner-title title MuiBox-root cssltr-e9ah7v"
+            className="BluiThreeLiner-title title title MuiBox-root cssltr-e9ah7v"
           >
             Title
           </div>
@@ -57,7 +52,7 @@ exports[`Component: BLUIAppBarExample BLUIAppBarExample renders examples correct
     className="MuiBox-root cssltr-fvxjzt"
   >
     <header
-      className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionSticky BluiAppBar-root Mui-expanded expanded cssltr-nx5hj5-MuiPaper-root-MuiAppBar-root"
+      className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionSticky BluiAppBar-root expanded cssltr-nx5hj5-MuiPaper-root-MuiAppBar-root"
       data-testid="blui-appbar-root"
       style={
         {
@@ -73,26 +68,19 @@ exports[`Component: BLUIAppBarExample BLUIAppBarExample renders examples correct
       >
         <div
           className="BluiThreeLiner-root liner MuiBox-root cssltr-uqb9nc"
-          classes={
-            {
-              "info": "info",
-              "subtitle": "subtitle",
-              "title": "title",
-            }
-          }
         >
           <div
-            className="BluiThreeLiner-title title MuiBox-root cssltr-e9ah7v"
+            className="BluiThreeLiner-title title title MuiBox-root cssltr-e9ah7v"
           >
             W/ Dynamic Content
           </div>
           <div
-            className="BluiThreeLiner-subtitle subtitle MuiBox-root cssltr-1666yuc"
+            className="BluiThreeLiner-subtitle subtitle subtitle MuiBox-root cssltr-1666yuc"
           >
             Subtitle
           </div>
           <div
-            className="BluiThreeLiner-info info MuiBox-root cssltr-9q8ecb"
+            className="BluiThreeLiner-info info info MuiBox-root cssltr-9q8ecb"
           >
             Info
           </div>
@@ -129,7 +117,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
       }
     >
       <div
-        className="BluiScoreCard-header MuiBox-root cssltr-1vm5ien"
+        className="BluiScoreCard-header MuiBox-root cssltr-4ekqjb"
         data-testid="blui-score-card-header"
       >
         <div
@@ -191,7 +179,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
       }
     >
       <div
-        className="BluiScoreCard-header MuiBox-root cssltr-mam46"
+        className="BluiScoreCard-header MuiBox-root cssltr-4ekqjb"
         data-testid="blui-score-card-header"
       >
         <div
@@ -268,7 +256,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
       }
     >
       <div
-        className="BluiScoreCard-header MuiBox-root cssltr-mam46"
+        className="BluiScoreCard-header MuiBox-root cssltr-4ekqjb"
         data-testid="blui-score-card-header"
       >
         <div
@@ -387,7 +375,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
         className="MuiList-root MuiList-padding cssltr-12kkqz5-MuiList-root"
       >
         <li
-          className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-1fmyo93-MuiListItem-root"
+          className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-1lt4ou4-MuiListItem-root"
           onClick={[Function]}
         >
           <div
@@ -406,7 +394,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
           </div>
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium BluiInfoListItem-chevron cssltr-1jm4sjb-MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium BluiInfoListItem-chevron cssltr-1587uyb-MuiSvgIcon-root"
             data-testid="ChevronRightIcon"
             focusable="false"
             role="button"
@@ -434,7 +422,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
       }
     >
       <div
-        className="BluiScoreCard-header MuiBox-root cssltr-mam46"
+        className="BluiScoreCard-header MuiBox-root cssltr-4ekqjb"
         data-testid="blui-score-card-header"
       >
         <div
@@ -517,16 +505,14 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
         >
           <div
             className="BluiHeroBanner-root MuiBox-root cssltr-srjk1z"
-            classes={{}}
             data-testid="blui-hero-banner-root"
           >
             <div
-              className="BluiHero-root MuiBox-root cssltr-2a12sz"
-              classes={{}}
+              className="BluiHero-root MuiBox-root cssltr-bocl9p"
               data-testid="blui-hero-root"
             >
               <div
-                className="BluiHero-icon MuiBox-root cssltr-1tmkfrg"
+                className="BluiHero-icon MuiBox-root cssltr-17a4wol"
               >
                 <svg
                   aria-hidden={true}
@@ -546,13 +532,11 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
                 </svg>
               </div>
               <span
-                className="BluiHero-values cssltr-v1bge9"
+                className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
               >
                 <span
-                  className="BluiChannelValue-root cssltr-v74076"
-                  color="inherit"
+                  className="BluiChannelValue-root MuiBox-root cssltr-whg9xq"
                   data-testid="blui-channel-value-root"
-                  fontSize="normal"
                 >
                   <h6
                     className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -578,12 +562,11 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
               </p>
             </div>
             <div
-              className="BluiHero-root MuiBox-root cssltr-2a12sz"
-              classes={{}}
+              className="BluiHero-root MuiBox-root cssltr-bocl9p"
               data-testid="blui-hero-root"
             >
               <div
-                className="BluiHero-icon MuiBox-root cssltr-1tmkfrg"
+                className="BluiHero-icon MuiBox-root cssltr-17a4wol"
               >
                 <svg
                   aria-hidden={true}
@@ -603,13 +586,11 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
                 </svg>
               </div>
               <span
-                className="BluiHero-values cssltr-v1bge9"
+                className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
               >
                 <span
-                  className="BluiChannelValue-root cssltr-v74076"
-                  color="inherit"
+                  className="BluiChannelValue-root MuiBox-root cssltr-whg9xq"
                   data-testid="blui-channel-value-root"
-                  fontSize="normal"
                 >
                   <h6
                     className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -644,7 +625,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
         className="MuiList-root MuiList-padding cssltr-12kkqz5-MuiList-root"
       >
         <li
-          className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-1fmyo93-MuiListItem-root"
+          className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-1lt4ou4-MuiListItem-root"
           onClick={[Function]}
         >
           <div
@@ -663,7 +644,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
           </div>
           <svg
             aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium BluiInfoListItem-chevron cssltr-1jm4sjb-MuiSvgIcon-root"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium BluiInfoListItem-chevron cssltr-1587uyb-MuiSvgIcon-root"
             data-testid="ChevronRightIcon"
             focusable="false"
             role="button"
@@ -688,7 +669,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
     }
   >
     <div
-      className="BluiScoreCard-header MuiBox-root cssltr-1vm5ien"
+      className="BluiScoreCard-header MuiBox-root cssltr-4ekqjb"
       data-testid="blui-score-card-header"
     >
       <div
@@ -765,7 +746,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
               }
             >
               <div
-                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-w8i9qu-MuiAvatar-root"
+                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-y3kntj-MuiAvatar-root"
               >
                 <svg
                   aria-hidden={true}
@@ -807,7 +788,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
               }
             >
               <div
-                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-1rsioro-MuiAvatar-root"
+                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-8yxl6e-MuiAvatar-root"
               >
                 <svg
                   aria-hidden={true}
@@ -849,7 +830,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
               }
             >
               <div
-                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-w8i9qu-MuiAvatar-root"
+                className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault BluiInfoListItem-icon cssltr-y3kntj-MuiAvatar-root"
               >
                 <svg
                   aria-hidden={true}
@@ -883,16 +864,14 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
       >
         <div
           className="BluiHeroBanner-root MuiBox-root cssltr-srjk1z"
-          classes={{}}
           data-testid="blui-hero-banner-root"
         >
           <div
-            className="BluiHero-root MuiBox-root cssltr-2a12sz"
-            classes={{}}
+            className="BluiHero-root MuiBox-root cssltr-bocl9p"
             data-testid="blui-hero-root"
           >
             <div
-              className="BluiHero-icon MuiBox-root cssltr-ca2ftl"
+              className="BluiHero-icon MuiBox-root cssltr-1ehupy8"
             >
               <svg
                 aria-hidden={true}
@@ -911,13 +890,11 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
               </svg>
             </div>
             <span
-              className="BluiHero-values cssltr-v1bge9"
+              className="BluiHero-values MuiBox-root cssltr-1lgzb0a"
             >
               <span
-                className="BluiChannelValue-root cssltr-v74076"
-                color="inherit"
+                className="BluiChannelValue-root MuiBox-root cssltr-whg9xq"
                 data-testid="blui-channel-value-root"
-                fontSize="normal"
               >
                 <h6
                   className="MuiTypography-root MuiTypography-h6 BluiChannelValue-text BluiChannelValue-value cssltr-l646db-MuiTypography-root"
@@ -952,7 +929,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
       className="MuiList-root MuiList-padding cssltr-12kkqz5-MuiList-root"
     >
       <li
-        className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-1fmyo93-MuiListItem-root"
+        className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding BluiInfoListItem-root cssltr-1lt4ou4-MuiListItem-root"
         onClick={[Function]}
       >
         <div
@@ -971,7 +948,7 @@ exports[`Component: ScoreCardExample ScoreCardExample renders examples correctly
         </div>
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium BluiInfoListItem-chevron cssltr-1jm4sjb-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium BluiInfoListItem-chevron cssltr-1587uyb-MuiSvgIcon-root"
           data-testid="ChevronRightIcon"
           focusable="false"
           role="button"
@@ -1009,21 +986,18 @@ exports[`Component: SpacerExample SpacerExample renders examples correctly 1`] =
     >
       <div
         className="BluiSpacer-root MuiBox-root cssltr-zrkb6b"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         1
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-4ikeoe"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         2
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-ihz316"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         3
@@ -1044,21 +1018,18 @@ exports[`Component: SpacerExample SpacerExample renders examples correctly 1`] =
     >
       <div
         className="BluiSpacer-root MuiBox-root cssltr-zrkb6b"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         1
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-4ikeoe"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         2
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-ihz316"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         3
@@ -1085,21 +1056,18 @@ exports[`Component: SpacerExample SpacerExample renders examples correctly 1`] =
     >
       <div
         className="BluiSpacer-root MuiBox-root cssltr-1cb72ie"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         1
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-p8ehs9"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         2
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-eqp6ib"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         3
@@ -1120,21 +1088,18 @@ exports[`Component: SpacerExample SpacerExample renders examples correctly 1`] =
     >
       <div
         className="BluiSpacer-root MuiBox-root cssltr-jg34ma"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         1
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-vpradr"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         2
       </div>
       <div
         className="BluiSpacer-root MuiBox-root cssltr-zxma3v"
-        classes={{}}
         data-testid="blui-spacer-root"
       >
         3

--- a/src/components/material-ui/data-display/Divider.tsx
+++ b/src/components/material-ui/data-display/Divider.tsx
@@ -4,7 +4,6 @@ import Typography from '@mui/material/Typography';
 import Avatar from '@mui/material/Avatar';
 import Divider from '@mui/material/Divider';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
 import Grid from '@mui/material/Grid';
@@ -16,6 +15,7 @@ import FormatBoldIcon from '@mui/icons-material/FormatBold';
 import FormatItalicIcon from '@mui/icons-material/FormatItalic';
 import FormatUnderlinedIcon from '@mui/icons-material/FormatUnderlined';
 import Box from '@mui/material/Box';
+import ListItemButton from '@mui/material/ListItemButton';
 
 const ContainerStyles = {
     mb: 4,
@@ -40,64 +40,64 @@ export const DividerExample: React.FC = () => {
                 </Typography>
                 <Box sx={DividerContainerStyles}>
                     <List>
-                        <ListItem button>
+                        <ListItemButton>
                             <ListItemAvatar>
                                 <Avatar>
                                     <PxblueSmall />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary="Full Width Divider" />
-                        </ListItem>
+                        </ListItemButton>
                         <Divider />
-                        <ListItem button>
+                        <ListItemButton>
                             <ListItemAvatar>
                                 <Avatar>
                                     <PxblueSmall />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary="Light Full Width Divider" />
-                        </ListItem>
-                        <Divider light />
+                        </ListItemButton>
+                        <Divider sx={{ opacity: 0.6 }} />
                     </List>
                     <List>
-                        <ListItem button>
+                        <ListItemButton>
                             <ListItemAvatar>
                                 <Avatar>
                                     <PxblueSmall />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary="Inset Divider" />
-                        </ListItem>
+                        </ListItemButton>
                         <Divider variant={'inset'} />
-                        <ListItem button>
+                        <ListItemButton>
                             <ListItemAvatar>
                                 <Avatar>
                                     <PxblueSmall />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary="Light Inset Divider" />
-                        </ListItem>
-                        <Divider light variant={'inset'} />
+                        </ListItemButton>
+                        <Divider sx={{ opacity: 0.6 }} variant={'inset'} />
                     </List>
                     <List>
-                        <ListItem button>
+                        <ListItemButton>
                             <ListItemAvatar>
                                 <Avatar>
                                     <PxblueSmall />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary="Middle Divider" />
-                        </ListItem>
+                        </ListItemButton>
                         <Divider variant={'middle'} />
-                        <ListItem button>
+                        <ListItemButton>
                             <ListItemAvatar>
                                 <Avatar>
                                     <PxblueSmall />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary="Light Middle Divider" />
-                        </ListItem>
-                        <Divider light variant={'middle'} />
+                        </ListItemButton>
+                        <Divider sx={{ opacity: 0.6 }} variant={'middle'} />
                     </List>
                 </Box>
             </Box>

--- a/src/components/material-ui/feedback/Dialog.tsx
+++ b/src/components/material-ui/feedback/Dialog.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -17,6 +16,7 @@ import IconButton from '@mui/material/IconButton';
 import { TransitionProps } from '@mui/material/transitions/transition';
 import Close from '@mui/icons-material/Close';
 import Box from '@mui/material/Box';
+import ListItemButton from '@mui/material/ListItemButton';
 
 const buttonStyles = {
     mb: 2,
@@ -106,26 +106,26 @@ export const DialogExample: React.FC = () => {
                     </Toolbar>
                 </AppBar>
                 <List>
-                    <ListItem button>
+                    <ListItemButton>
                         <ListItemText
                             primary="AppBar"
                             secondary="An extension of the default AppBar from Material UI that can be resized / collapsed as the page is scrolled"
                         />
-                    </ListItem>
+                    </ListItemButton>
                     <Divider />
-                    <ListItem button>
+                    <ListItemButton>
                         <ListItemText
                             primary="ChannelValue"
                             secondary="A component used to display...a channel value (and units)"
                         />
-                    </ListItem>
+                    </ListItemButton>
                     <Divider />
-                    <ListItem button>
+                    <ListItemButton>
                         <ListItemText
                             primary="EmptyState"
                             secondary="A component that can be used as a placeholder when no data is present"
                         />
-                    </ListItem>
+                    </ListItemButton>
                 </List>
             </Dialog>
         </Box>

--- a/src/components/material-ui/feedback/Snackbar.tsx
+++ b/src/components/material-ui/feedback/Snackbar.tsx
@@ -11,9 +11,9 @@ const buttonStyles = {
     width: 300,
 };
 
-const Alert: React.FC<AlertProps> = forwardRef((props, ref) => (
+const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => (
     <MuiAlert elevation={6} variant="filled" {...props} ref={ref} />
-));
+)) as React.ForwardRefExoticComponent<AlertProps & React.RefAttributes<HTMLDivElement>>;
 
 export const SnackbarExample: React.FC = () => {
     const [open, setOpen] = React.useState(false);

--- a/src/components/material-ui/inputs/DateTime.tsx
+++ b/src/components/material-ui/inputs/DateTime.tsx
@@ -1,5 +1,4 @@
-import React, { ReactElement } from 'react';
-import TextField, { TextFieldProps } from '@mui/material/TextField';
+import React from 'react';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider, DatePicker, MobileDatePicker, MobileTimePicker } from '@mui/x-date-pickers';
 import Box from '@mui/material/Box';
@@ -22,7 +21,7 @@ export const DateTimeExample: React.FC = () => {
                     label="Date picker inline"
                     value={selectedDate}
                     onChange={handleDateChange}
-                    renderInput={(params: TextFieldProps): ReactElement => <TextField {...params} />}
+                    slotProps={{ textField: { variant: 'outlined' } }}
                 />
             </Box>
             <Box sx={dateTimeContainerStyles}>
@@ -30,7 +29,7 @@ export const DateTimeExample: React.FC = () => {
                     label="Date picker dialog"
                     value={selectedDate}
                     onChange={handleDateChange}
-                    renderInput={(params: TextFieldProps): ReactElement => <TextField {...params} />}
+                    slotProps={{ textField: { variant: 'outlined' } }}
                 />
             </Box>
             <Box sx={dateTimeContainerStyles}>
@@ -38,7 +37,7 @@ export const DateTimeExample: React.FC = () => {
                     label="Time picker"
                     value={selectedDate}
                     onChange={handleDateChange}
-                    renderInput={(params: TextFieldProps): ReactElement => <TextField {...params} />}
+                    slotProps={{ textField: { variant: 'outlined' } }}
                 />
             </Box>
         </LocalizationProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,18 +17,24 @@ import { RTLThemeProvider } from './components/RTLProvider';
 import '@brightlayer-ui/react-themes/open-sans';
 
 const container = document.getElementById('root');
+
 /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
 const root = createRoot(container!);
+/* eslint-disable */
 declare global {
     namespace React {
         interface DOMAttributes<T> {
+            component?: string | undefined;
+            disabled?: string | undefined;
+            selected?: string | undefined;
             placeholder?: string | undefined;
             onPointerEnterCapture?: React.PointerEventHandler<T> | undefined;
             onPointerLeaveCapture?: any;
         }
     }
 }
- 
+/* eslint-disable */
+
 root.render(
     <React.StrictMode>
         <Provider store={store}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@
 
  This code is licensed under the BSD-3 license found in the LICENSE file in the root directory of this source tree and at https://opensource.org/licenses/BSD-3-Clause.
  **/
+/* eslint-disable */
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 // import * as {serviceWorker} from './serviceWorker';

--- a/src/pages/contextual-page-templates/Alarms.tsx
+++ b/src/pages/contextual-page-templates/Alarms.tsx
@@ -143,7 +143,7 @@ export const Alarms: React.FC = () => {
     const getBadgeColor = (badge: string): string => {
         switch (badge) {
             case 'active':
-                return theme.palette.error.main;     // @TODO: Change it to (theme.vars || theme).palette.error.main
+                return theme.palette.error.main; // @TODO: Change it to (theme.vars || theme).palette.error.main
             case 'new':
             default:
                 return theme.palette.primary.main;

--- a/src/pages/contextual-page-templates/Dashboard.tsx
+++ b/src/pages/contextual-page-templates/Dashboard.tsx
@@ -277,7 +277,8 @@ export const Dashboard: React.FC = () => {
                                         backgroundColor={(theme.vars || theme).palette.background.default}
                                         label={'active'}
                                         fontColor={
-                                            theme.applyStyles('dark', { color: Colors.green[500] }).color as string || Colors.blue[700]
+                                            (theme.applyStyles('dark', { color: Colors.green[500] }).color as string) ||
+                                            Colors.blue[700]
                                         }
                                         sx={listTagStyles}
                                     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,16 +1308,16 @@
     marked "^14.1.3"
     prismjs "^1.29.0"
 
-"@mui/lab@^6.0.0-beta.12":
-  version "6.0.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-6.0.0-beta.14.tgz#f548fb4207e7694d6df0f38ca20f6a5600696c70"
-  integrity sha512-l+g8z6QGcr7HdfCXhVaYcEp9TijH/G4h0lNaDaBL+qDFQ087ipNHC+XozE7mXOmBwtEAWmTJB4E5GwDboi9oxA==
+"@mui/lab@^6.0.0-beta.14":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-6.0.0-beta.15.tgz#32e7ab50d4c8131caea079a137f625da77fbac4d"
+  integrity sha512-LwX34gdIBBpIHi0RkWUjktCnX1rEB+U2tOzDKfF2f4h+GXTO+DOjAXTkFw558zQ8SWmpQTOUp58sGRxlZ2x9FQ==
   dependencies:
     "@babel/runtime" "^7.26.0"
     "@mui/base" "5.0.0-beta.61"
-    "@mui/system" "^6.1.6"
+    "@mui/system" "^6.1.7"
     "@mui/types" "^7.2.19"
-    "@mui/utils" "^6.1.6"
+    "@mui/utils" "^6.1.7"
     clsx "^2.1.1"
     prop-types "^15.8.1"
 
@@ -1348,6 +1348,15 @@
     "@mui/utils" "^6.1.6"
     prop-types "^15.8.1"
 
+"@mui/private-theming@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-6.1.7.tgz#9415c32eb567194b713941243cf18fde09981ba1"
+  integrity sha512-uLbfUSsug5K0LVkv0PI6Flste3le8+6WSL2omdTiYde93P89Qr7pKr8TA6d2yXfr+Bm+SvD8/fGnkaRwFkryuQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mui/utils" "^6.1.7"
+    prop-types "^15.8.1"
+
 "@mui/styled-engine-sc@^6.1.4":
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/@mui/styled-engine-sc/-/styled-engine-sc-6.1.6.tgz#44621bde44c4fff53c99df42aa9a8452fcaca307"
@@ -1362,6 +1371,18 @@
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-6.1.6.tgz#61996621a0297aac16061e1739a738a899613fd6"
   integrity sha512-I+yS1cSuSvHnZDBO7e7VHxTWpj+R7XlSZvTC4lS/OIbUNJOMMSd3UDP6V2sfwzAdmdDNBi7NGCRv2SZ6O9hGDA==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@emotion/cache" "^11.13.1"
+    "@emotion/serialize" "^1.3.2"
+    "@emotion/sheet" "^1.4.0"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+
+"@mui/styled-engine@^6.1.7":
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-6.1.8.tgz#8e99ff036d171b811eff0f0421c7aae8b0b9ac35"
+  integrity sha512-ZvEoT0U2nPLSLI+B4by4cVjaZnPT2f20f4JUPkyHdwLv65ZzuoHiTlwyhqX1Ch63p8bcJzKTHQVGisEoMK6PGA==
   dependencies:
     "@babel/runtime" "^7.26.0"
     "@emotion/cache" "^11.13.1"
@@ -1407,6 +1428,20 @@
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
+"@mui/system@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-6.1.7.tgz#041d450b842d5c2fb1608d4027360ad2ba25bd9a"
+  integrity sha512-qbMGgcC/FodpuRSfjXlEDdbNQaW++eATh0vNBcPUv2/YXSpReoOpoT9FhogxEBNks+aQViDXBRZKh6HX2fVmwg==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mui/private-theming" "^6.1.7"
+    "@mui/styled-engine" "^6.1.7"
+    "@mui/types" "^7.2.19"
+    "@mui/utils" "^6.1.7"
+    clsx "^2.1.1"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+
 "@mui/types@^7.2.18", "@mui/types@^7.2.19":
   version "7.2.19"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.19.tgz#c941954dd24393fdce5f07830d44440cf4ab6c80"
@@ -1416,6 +1451,18 @@
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.1.6.tgz#4b9fd34da3a1dd4700fe506a20ca7da3933ba48e"
   integrity sha512-sBS6D9mJECtELASLM+18WUcXF6RH3zNxBRFeyCRg8wad6NbyNrdxLuwK+Ikvc38sTZwBzAz691HmSofLqHd9sQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mui/types" "^7.2.19"
+    "@types/prop-types" "^15.7.13"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^18.3.1"
+
+"@mui/utils@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.1.7.tgz#0959d9772ae13c6ceac984a493e06aebb9087e71"
+  integrity sha512-Gr7cRZxBoZ0BIa3Xqf/2YaUrBLyNPJvXPQH3OsD9WMZukI/TutibbQBVqLYpgqJn8pKSjbD50Yq2auG0wI1xOw==
   dependencies:
     "@babel/runtime" "^7.26.0"
     "@mui/types" "^7.2.19"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .
I was going to suggest some changes in https://github.com/etn-ccis/blui-react-showcase-demo/pull/177 but seemed better to just open new PR to merge in to #177 .


<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- temporary fix so we can build, test, lint & deploy

- updated DOMAttributes<T> {
            component?: string | undefined;
            disabled?: string | undefined;
            selected?: string | undefined;
- updated `<ListItem button> to <ListItemButton>`
- updated `<Divider light /> to <Divider sx={{ opacity: 0.6 }} />`
- updated forwardRef on Alert
- updated datePicker to use slotProps={{ textField: { variant: 'outlined' } }}

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- clone and build https://github.com/etn-ccis/blui-react-themes
- copy theme dist content over to showcase modules
- yarn lint && yarn prettier && yarn test && yarn build && yarn preview

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
